### PR TITLE
Ability to look around without rotating pill

### DIFF
--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -677,7 +677,7 @@ function ENT:Think()
     if self.formTable.freelook then
         freelook = self.formTable.freelook(ply, self)
     end
-    if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and !freelook then
+    if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and not freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
 
@@ -687,7 +687,7 @@ function ENT:Think()
             --puppet:SetAngles(angs)
             puppet:SetRenderAngles(angs)
         end
-    elseif vel > 0  and freelook then
+    elseif vel > 0 and freelook then
         local dirangle = ply:GetVelocity():Angle()
         dirangle.p = 0
         if SERVER then

--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -673,7 +673,11 @@ function ENT:Think()
         puppet:SetRenderOrigin(ply:GetPos())
     end
 
-    if vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60 then
+    local freelook = nil
+    if self.formTable.freelook then
+        freelook = self.formTable.freelook(ply, self)
+    end
+    if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and !freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
 
@@ -682,6 +686,14 @@ function ENT:Think()
         else
             --puppet:SetAngles(angs)
             puppet:SetRenderAngles(angs)
+        end
+    elseif vel > 0  and freelook then
+        local dirangle = ply:GetVelocity():Angle()
+        dirangle.p = 0
+        if SERVER then
+            puppet:SetAngles(dirangle)
+        else
+            puppet:SetRenderAngles(dirangle)
         end
     end
 


### PR DESCRIPTION
Adds a function parameter that tells the entity whether to rotate the pill based on the direction it's going, or where the player is looking (default).