### PR TITLE
anim cancel & free look fixes

### DIFF
--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -677,6 +677,7 @@ function ENT:Think()
     if self.formTable.freelook then
         freelook = self.formTable.freelook(ply, self)
     end
+    local pvel = ply:GetVelocity()
     if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and not freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
@@ -687,7 +688,7 @@ function ENT:Think()
             --puppet:SetAngles(angs)
             puppet:SetRenderAngles(angs)
         end
-    elseif vel > 0 and freelook then
+    elseif Vector(pvel.x, pvel.y, 0):Length() > 10 and freelook then
         local dirangle = ply:GetVelocity():Angle()
         dirangle.p = 0
         if SERVER then

--- a/lua/includes/modules/pk_pills.lua
+++ b/lua/includes/modules/pk_pills.lua
@@ -947,7 +947,7 @@ if SERVER then
 
 	hook.Add("DoAnimationEvent", "pk_pill_triggerAnims", function(ply, event, data)
 		if IsValid(getMappedEnt(ply)) and getMappedEnt(ply).formTable.type == "ply" then
-			if event == PLAYERANIMEVENT_JUMP then
+			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).animFreeze then
 				getMappedEnt(ply):PillAnim("jump")
 				getMappedEnt(ply):DoJump()
 			end


### PR DESCRIPTION
### Animations:
Fixed an issue (possible oversight?) where jumping would cancel whatever special animation is currently playing, as well as formTable.jump getting called despite animFreeze being true. This behavior is inconsistent with the rest which leads me to believe it is an oversight.

### Free look
Adjusted the minimal velocity required to rotate the pill to 10 units. Also ignores the z axis. Without these changes, strange behavior can occur when either idle jumping or jumping on a slope with jumpPower at 0. The 10 units threshold is arbitrary, but shouldn't realistically cause any issues.