### PR TITLE
Animation Cancel Fix

### DIFF
--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -677,7 +677,6 @@ function ENT:Think()
     if self.formTable.freelook then
         freelook = self.formTable.freelook(ply, self)
     end
-    local pvel = ply:GetVelocity()
     if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and not freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
@@ -688,7 +687,7 @@ function ENT:Think()
             --puppet:SetAngles(angs)
             puppet:SetRenderAngles(angs)
         end
-    elseif Vector(pvel.x, pvel.y, 0):Length() > 10 and freelook then
+    elseif vel > 0 and freelook then
         local dirangle = ply:GetVelocity():Angle()
         dirangle.p = 0
         if SERVER then

--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -677,6 +677,7 @@ function ENT:Think()
     if self.formTable.freelook then
         freelook = self.formTable.freelook(ply, self)
     end
+    local pvel = ply:GetVelocity()
     if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and not freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
@@ -687,7 +688,7 @@ function ENT:Think()
             --puppet:SetAngles(angs)
             puppet:SetRenderAngles(angs)
         end
-    elseif vel > 0 and freelook then
+    elseif Vector(pvel.x, pvel.y, 0):Length() > 10 and freelook then
         local dirangle = ply:GetVelocity():Angle()
         dirangle.p = 0
         if SERVER then

--- a/lua/includes/modules/pk_pills.lua
+++ b/lua/includes/modules/pk_pills.lua
@@ -947,7 +947,7 @@ if SERVER then
 
 	hook.Add("DoAnimationEvent", "pk_pill_triggerAnims", function(ply, event, data)
 		if IsValid(getMappedEnt(ply)) and getMappedEnt(ply).formTable.type == "ply" then
-			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).animFreeze then
+			if event == PLAYERANIMEVENT_JUMP then
 				getMappedEnt(ply):PillAnim("jump")
 				getMappedEnt(ply):DoJump()
 			end

--- a/lua/includes/modules/pk_pills.lua
+++ b/lua/includes/modules/pk_pills.lua
@@ -946,22 +946,23 @@ if SERVER then
 	end)
 
 	hook.Add("DoAnimationEvent", "pk_pill_triggerAnims", function(ply, event, data)
-		if IsValid(getMappedEnt(ply)) and getMappedEnt(ply).formTable.type == "ply" then
-			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).nojump then
-				getMappedEnt(ply):PillAnim("jump")
-				getMappedEnt(ply):DoJump()
+		local ent = getMappedEnt(ply)
+		if IsValid(ent) and ent.formTable.type == "ply" then
+			if event == PLAYERANIMEVENT_JUMP and not ent.nojump then
+				ent:PillAnim("jump")
+				ent:DoJump()
 			end
 
 			if event == PLAYERANIMEVENT_ATTACK_PRIMARY then
-				getMappedEnt(ply):PillGesture("attack")
+				ent:PillGesture("attack")
 			end
 
 			if event == PLAYERANIMEVENT_ATTACK_SECONDARY then
-				getMappedEnt(ply):PillGesture("attack2")
+				ent:PillGesture("attack2")
 			end
 
 			if event == PLAYERANIMEVENT_RELOAD then
-				getMappedEnt(ply):PillGesture("reload")
+				ent:PillGesture("reload")
 			end
 		end
 	end)

--- a/lua/includes/modules/pk_pills.lua
+++ b/lua/includes/modules/pk_pills.lua
@@ -947,7 +947,7 @@ if SERVER then
 
 	hook.Add("DoAnimationEvent", "pk_pill_triggerAnims", function(ply, event, data)
 		if IsValid(getMappedEnt(ply)) and getMappedEnt(ply).formTable.type == "ply" then
-			if event == PLAYERANIMEVENT_JUMP then
+			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).animFreeze then
 				getMappedEnt(ply):PillAnim("jump")
 				getMappedEnt(ply):DoJump()
 			end

--- a/lua/includes/modules/pk_pills.lua
+++ b/lua/includes/modules/pk_pills.lua
@@ -947,7 +947,7 @@ if SERVER then
 
 	hook.Add("DoAnimationEvent", "pk_pill_triggerAnims", function(ply, event, data)
 		if IsValid(getMappedEnt(ply)) and getMappedEnt(ply).formTable.type == "ply" then
-			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).animFreeze then
+			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).nojump then
 				getMappedEnt(ply):PillAnim("jump")
 				getMappedEnt(ply):DoJump()
 			end


### PR DESCRIPTION
Fixed an issue (possible oversight?) where jumping would cancel whatever special animation is currently playing, as well as formTable.jump getting called despite animFreeze being true. This behavior is inconsistent with the rest which leads me to believe it is an oversight.