### PR TITLE
Free look Velocity Fix 

### DIFF
--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -677,7 +677,6 @@ function ENT:Think()
     if self.formTable.freelook then
         freelook = self.formTable.freelook(ply, self)
     end
-    local pvel = ply:GetVelocity()
     if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and not freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
@@ -688,7 +687,7 @@ function ENT:Think()
             --puppet:SetAngles(angs)
             puppet:SetRenderAngles(angs)
         end
-    elseif Vector(pvel.x, pvel.y, 0):Length() > 10 and freelook then
+    elseif vel > 0 and freelook then
         local dirangle = ply:GetVelocity():Angle()
         dirangle.p = 0
         if SERVER then

--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -302,7 +302,8 @@ function ENT:Think()
     local ply = self:GetPillUser()
     local puppet = self:GetPuppet()
     if not IsValid(puppet) or not IsValid(ply) then return end
-    local vel = ply:GetVelocity():Length()
+    local pvel = ply:GetVelocity()
+    local vel = pvel:Length()
 
     if SERVER then
         --Anims
@@ -404,11 +405,11 @@ function ENT:Think()
         if self.formTable.movePoseMode then
             --
             if self.formTable.movePoseMode == "yaw" then
-                local move_dir = puppet:WorldToLocalAngles(ply:GetVelocity():Angle())
+                local move_dir = puppet:WorldToLocalAngles(pvel:Angle())
                 puppet:SetPoseParameter("move_yaw", move_dir.y)
             elseif self.formTable.movePoseMode == "xy" then
                 if not overrideRate then
-                    local localvel = ply:WorldToLocal(ply:GetPos() + ply:GetVelocity())
+                    local localvel = ply:WorldToLocal(ply:GetPos() + pvel)
                     local maxdim = math.Max(math.abs(localvel.x), math.abs(localvel.y))
                     local clampedvel = maxdim == 0 and Vector(0, 0, 0) or localvel / maxdim
                     puppet:SetPoseParameter("move_x", clampedvel.x)
@@ -426,10 +427,10 @@ function ENT:Think()
                 end
             elseif self.formTable.movePoseMode == "xy-bot" then
                 if not overrideRate then
-                    local localvel = ply:WorldToLocal(ply:GetPos() + ply:GetVelocity())
+                    local localvel = ply:WorldToLocal(ply:GetPos() + pvel)
                     local maxdim = math.Max(math.abs(localvel.x), math.abs(localvel.y))
                     local clampedvel = maxdim == 0 and Vector(0, 0, 0) or localvel / maxdim
-                    local move_dir = puppet:WorldToLocalAngles(ply:GetVelocity():Angle())
+                    local move_dir = puppet:WorldToLocalAngles(pvel:Angle())
                     puppet:SetPoseParameter("move_x", clampedvel.x)
                     puppet:SetPoseParameter("move_y", -clampedvel.y)
                     puppet:SetPoseParameter("move_yaw", move_dir.y)
@@ -677,7 +678,6 @@ function ENT:Think()
     if self.formTable.freelook then
         freelook = self.formTable.freelook(ply, self)
     end
-    local pvel = ply:GetVelocity()
     if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and not freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
@@ -689,7 +689,7 @@ function ENT:Think()
             puppet:SetRenderAngles(angs)
         end
     elseif Vector(pvel.x, pvel.y, 0):Length() > 10 and freelook then
-        local dirangle = ply:GetVelocity():Angle()
+        local dirangle = pvel:Angle()
         dirangle.p = 0
         if SERVER then
             puppet:SetAngles(dirangle)

--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -677,6 +677,7 @@ function ENT:Think()
     if self.formTable.freelook then
         freelook = self.formTable.freelook(ply, self)
     end
+    local pvel = ply:GetVelocity()
     if (vel > 0 or math.abs(math.AngleDifference(puppet:GetAngles().y, ply:EyeAngles().y)) > 60) and not freelook then
         local angs = ply:EyeAngles()
         angs.p = 0
@@ -687,7 +688,7 @@ function ENT:Think()
             --puppet:SetAngles(angs)
             puppet:SetRenderAngles(angs)
         end
-    elseif vel > 0 and freelook then
+    elseif Vector(pvel.x, pvel.y, 0):Length() > 10 and freelook then
         local dirangle = ply:GetVelocity():Angle()
         dirangle.p = 0
         if SERVER then

--- a/lua/includes/modules/pk_pills.lua
+++ b/lua/includes/modules/pk_pills.lua
@@ -947,7 +947,7 @@ if SERVER then
 
 	hook.Add("DoAnimationEvent", "pk_pill_triggerAnims", function(ply, event, data)
 		if IsValid(getMappedEnt(ply)) and getMappedEnt(ply).formTable.type == "ply" then
-			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).animFreeze then
+			if event == PLAYERANIMEVENT_JUMP then
 				getMappedEnt(ply):PillAnim("jump")
 				getMappedEnt(ply):DoJump()
 			end

--- a/lua/includes/modules/pk_pills.lua
+++ b/lua/includes/modules/pk_pills.lua
@@ -947,7 +947,7 @@ if SERVER then
 
 	hook.Add("DoAnimationEvent", "pk_pill_triggerAnims", function(ply, event, data)
 		if IsValid(getMappedEnt(ply)) and getMappedEnt(ply).formTable.type == "ply" then
-			if event == PLAYERANIMEVENT_JUMP then
+			if event == PLAYERANIMEVENT_JUMP and not getMappedEnt(ply).animFreeze then
 				getMappedEnt(ply):PillAnim("jump")
 				getMappedEnt(ply):DoJump()
 			end


### PR DESCRIPTION
Adjusted the minimal velocity required to rotate the pill to 10 units. Also ignores the z axis. Without these changes, strange behavior can occur when either idle jumping or jumping on a slope with jumpPower at 0. The 10 units threshold is arbitrary, but shouldn't realistically cause any issues.