### PR TITLE
Add dedicated entity variable to store pill move speeds.

### DIFF
--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -56,7 +56,8 @@ function ENT:Initialize()
         ply:SetStepSize(hull.z / 4)
         ply:SetViewOffset(camOffset)
         ply:SetViewOffsetDucked(camOffset - Vector(0, 0, duckBy))
-        local speed = self.formTable.moveSpeed or {}
+        self.pillspeed = self.formTable.moveSpeed or {}
+        local speed = self.pillspeed
         ply:SetWalkSpeed(speed.walk or 200)
         ply:SetRunSpeed(speed.run or speed.walk or 500)
 
@@ -323,7 +324,7 @@ function ENT:Think()
             ply:SetRunSpeed(ply:GetWalkSpeed() / 2)
             self.plyFrozen = true
         elseif not self.animFreeze and self.plyFrozen then
-            local speed = self.formTable.moveSpeed or {}
+            local speed = self.pillspeed or {}
             ply:SetWalkSpeed(speed.walk or 200)
             ply:SetRunSpeed(speed.run or speed.walk or 500)
             self.plyFrozen = nil

--- a/lua/entities/pill_ent_costume.lua
+++ b/lua/entities/pill_ent_costume.lua
@@ -324,7 +324,7 @@ function ENT:Think()
             ply:SetRunSpeed(ply:GetWalkSpeed() / 2)
             self.plyFrozen = true
         elseif not self.animFreeze and self.plyFrozen then
-            local speed = self.pillspeed or {}
+            local speed = self.pillspeed or self.formTable.moveSpeed or {}
             ply:SetWalkSpeed(speed.walk or 200)
             ply:SetRunSpeed(speed.run or speed.walk or 500)
             self.plyFrozen = nil


### PR DESCRIPTION
This small feature allows changing and storing a pill's speed in real time. Without it, there is an issue where if there are multple instances of the same pill, and one of them changes its formTable.moveSpeed via a function, then the others will also receive this change (it is refreshed when a PillAnim() sequence ends).
This change does not alter default behavior.